### PR TITLE
Enable PhpdocTypesOrderFixer

### DIFF
--- a/tools/ecs/config/default.php
+++ b/tools/ecs/config/default.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
-use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesOrderFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -23,8 +22,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '*/DependencyInjection/Configuration.php',
             '*/Resources/config/*.php',
         ],
-        // TODO: enable this again once https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6243 has been merged
-        PhpdocTypesOrderFixer::class => null,
         UnusedVariableSniff::class => [
             'core-bundle/tests/Session/Attribute/ArrayAttributeBagTest.php',
             'manager-bundle/src/Resources/skeleton/*.php',


### PR DESCRIPTION
This can be enabled now that https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6243 has been merged.

Originally added [here](https://github.com/contao/contao/commit/4849881532595317a5c8ef7b99a9677b88f08ebf#diff-a95817c1c2b59c07bf78b5c0565bdf836c7459dee80a13573ae1689c04440040).
